### PR TITLE
Update runtime from Freedesktop 19.08 (EOL) to 21.08

### DIFF
--- a/org.netsurf_browser.NetSurf.yaml
+++ b/org.netsurf_browser.NetSurf.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: org.netsurf_browser.NetSurf
 runtime: org.freedesktop.Platform
-runtime-version: "19.08"
+runtime-version: "20.08"
 sdk: org.freedesktop.Sdk
 command: netsurf-gtk3
 finish-args:

--- a/org.netsurf_browser.NetSurf.yaml
+++ b/org.netsurf_browser.NetSurf.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: org.netsurf_browser.NetSurf
 runtime: org.freedesktop.Platform
-runtime-version: "20.08"
+runtime-version: "21.08"
 sdk: org.freedesktop.Sdk
 command: netsurf-gtk3
 finish-args:


### PR DESCRIPTION
Freedesktop 19.08 is end-of-life, migrate to 20.08.

```
$ flatpak update org.netsurf_browser.NetSurf
Looking for updates…
Info: org.freedesktop.Platform//19.08 is end-of-life, with reason:
   The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
Applications using this runtime:
   org.netsurf_browser.NetSurf
Info: org.freedesktop.Platform.VAAPI.Intel//19.08 is end-of-life, with reason:
   The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
Info: org.freedesktop.Platform.GL.default//19.08 is end-of-life, with reason:
   The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
Nothing to do.
```